### PR TITLE
Division Summary support

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -1745,7 +1745,7 @@ footer .right>span:nth-child(2) {
     width: 223px;
 }
 /*for custom ng-scrollbar*/
-.panelContestStat .panel-body .scheduleContent.scroll { 
+.panelContestStat .panel-body .scheduleContent.scroll {
     overflow-y: hidden;
 }
 /*for default scrollbar*/
@@ -2751,7 +2751,7 @@ footer .right>span:nth-child(2) {
     padding-right: 0;
 }
 .detailPage .titleBar .btnBack,
-.codeArea .btnBack { 
+.codeArea .btnBack {
     float: right;
     color: #fff;
     background: #0999d1;
@@ -3142,7 +3142,7 @@ footer .right>span:nth-child(2) {
     padding-right: 0;
 }
 .detailPage .leaderboardWrapper .table .col1 {
-    width: 70px;
+    width: 58px;
 }
 .detailPage .leftSec .table .col1 .arrow {
     margin-left: 0;
@@ -3165,6 +3165,10 @@ footer .right>span:nth-child(2) {
 }
 .challengerWrapper .table .col2 {
     width: 29%;
+}
+.leaderboardWrapper .table .colR {
+    width: 30px;
+    font-weight: 100;
 }
 .leaderboardWrapper .table .col2 {
     width: 22%;
@@ -3207,7 +3211,25 @@ footer .right>span:nth-child(2) {
     display: inline-block;
     -ms-word-break:break-all;
     word-break:break-all;
+    font-weight: 300;
 }
+.detailPage section .table td .roomLeader{
+    display: inline-block;
+    -ms-word-break:break-all;
+    word-break:break-all;
+    font-weight: 700!important;
+}
+
+.leaderboardWrapper .table td.col2 {
+    cursor: pointer;
+}
+
+.leaderboardWrapper .table td.colR {
+    cursor: pointer;
+    text-align: right;
+    padding-right: 1px;
+}
+
 .detailPage section .table td .rating {
     color: #636d70;
 }
@@ -3237,17 +3259,102 @@ footer .right>span:nth-child(2) {
     background-position: -31px -41px;
     margin-top: 6px;
 }
-.detailPage .leaderboardWrapper .colorPassed, 
-.detailPage .leaderboardWrapper .colorPending,
-.detailPage .leaderboardWrapper .colorSubmitted {
+
+/**** Default language ****/
+.detailPage .leaderboardWrapper .colorSubmittedDefault {
+    color: #ac4141;
+}
+.detailPage .leaderboardWrapper .colorChallengedDefault {
+    color: #ac4141;
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedDefault {
+    color: #ac4141;
+}
+.detailPage .leaderboardWrapper .colorFailedDefault {
+    color: #ac4141;
+    font-style: italic!important;
+}
+/**** Java language ****/
+.detailPage .leaderboardWrapper .colorSubmittedJava {
+    color: rgb(0, 255, 0);
+}
+.detailPage .leaderboardWrapper .colorChallengedJava {
+    color: rgb(0, 255, 0);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedJava {
+    color: rgb(0, 255, 0);
+}
+.detailPage .leaderboardWrapper .colorFailedJava {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** CPP language ****/
+.detailPage .leaderboardWrapper .colorSubmittedCpp {
+    color: rgb(255, 255, 153);
+}
+.detailPage .leaderboardWrapper .colorChallengedCpp {
+    color: rgb(255, 255, 153);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedCpp {
+    color: rgb(255, 255, 153);
+}
+.detailPage .leaderboardWrapper .colorFailedCpp {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** C# language ****/
+.detailPage .leaderboardWrapper .colorSubmittedCsharp {
+    color: rgb(102, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedCsharp {
+    color: rgb(102, 102, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedCsharp {
+    color: rgb(102, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedCsharp {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}/**** VB language ****/
+.detailPage .leaderboardWrapper .colorSubmittedVB {
+    color: rgb(129, 217, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedVB {
+    color: rgb(129, 217, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedVB {
+    color: rgb(129, 217, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedVB {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** Python language ****/
+.detailPage .leaderboardWrapper .colorSubmittedPython {
+    color: rgb(255, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedPython {
+    color: rgb(255, 102, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedPython {
+    color: rgb(255, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedPython {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+
+.detailPage .leaderboardWrapper .colorPending {
     color: #2c8236;
 }
 .detailPage .leaderboardWrapper .colorCompiled {
     color: #f99800;
-}
-.detailPage .leaderboardWrapper .colorChallenged,
-.detailPage .leaderboardWrapper .colorFailed {
-    color: #ac4141;
 }
 .detailPage .leaderboardWrapper .colorOpened {
     color: #fff;

--- a/app/css/dark/darkTheme.css
+++ b/app/css/dark/darkTheme.css
@@ -608,17 +608,101 @@ footer .right .sponsorLogo {
 .detailPage .table>tbody>tr>td>.rating {
     color: #636d70;
 }
-.detailPage .leaderboardWrapper .colorPassed,
-.detailPage .leaderboardWrapper .colorPending,
-.detailPage .leaderboardWrapper .colorSubmitted {
+/**** Default language ****/
+.detailPage .leaderboardWrapper .colorSubmittedDefault {
+    color: #ac4141;
+}
+.detailPage .leaderboardWrapper .colorChallengedDefault {
+    color: #ac4141;
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedDefault {
+    color: #ac4141;
+}
+.detailPage .leaderboardWrapper .colorFailedDefault {
+    color: #ac4141;
+    font-style: italic!important;
+}
+/**** Java language ****/
+.detailPage .leaderboardWrapper .colorSubmittedJava {
+    color: rgb(0, 255, 0);
+}
+.detailPage .leaderboardWrapper .colorChallengedJava {
+    color: rgb(0, 255, 0);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedJava {
+    color: rgb(0, 255, 0);
+}
+.detailPage .leaderboardWrapper .colorFailedJava {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** CPP language ****/
+.detailPage .leaderboardWrapper .colorSubmittedCpp {
+    color: rgb(255, 255, 153);
+}
+.detailPage .leaderboardWrapper .colorChallengedCpp {
+    color: rgb(255, 255, 153);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedCpp {
+    color: rgb(255, 255, 153);
+}
+.detailPage .leaderboardWrapper .colorFailedCpp {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** C# language ****/
+.detailPage .leaderboardWrapper .colorSubmittedCsharp {
+    color: rgb(102, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedCsharp {
+    color: rgb(102, 102, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedCsharp {
+    color: rgb(102, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedCsharp {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}/**** VB language ****/
+.detailPage .leaderboardWrapper .colorSubmittedVB {
+    color: rgb(129, 217, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedVB {
+    color: rgb(129, 217, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedVB {
+    color: rgb(129, 217, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedVB {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** Python language ****/
+.detailPage .leaderboardWrapper .colorSubmittedPython {
+    color: rgb(255, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedPython {
+    color: rgb(255, 102, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedPython {
+    color: rgb(255, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedPython {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+
+.detailPage .leaderboardWrapper .colorPending {
     color: #2c8236;
 }
 .detailPage .leaderboardWrapper .colorCompiled {
     color: #f99800;
-}
-.detailPage .leaderboardWrapper .colorChallenged,
-.detailPage .leaderboardWrapper .colorFailed {
-    color: #ac4141;
 }
 .detailPage .leaderboardWrapper .colorOpened {
     color: #fff;
@@ -626,6 +710,7 @@ footer .right .sponsorLogo {
 .detailPage .leaderboardWrapper .colorUnopened {
     color: #5e676a;
 }
+
 .body .ngsb-wrap .ngsb-scrollbar .ngsb-thumb-pos .ngsb-thumb {
     background: #2a2b2c;
 }

--- a/app/css/light/lightTheme.css
+++ b/app/css/light/lightTheme.css
@@ -630,17 +630,102 @@ footer .right .sponsorLogo {
 .detailPage .table>tbody>tr>td>.rating{
     color: #316f99;
 }
-.detailPage .leaderboardWrapper .colorPassed,
-.detailPage .leaderboardWrapper .colorPending,
-.detailPage .leaderboardWrapper .colorSubmitted {
+
+/**** Default language ****/
+.detailPage .leaderboardWrapper .colorSubmittedDefault {
+    color: #ac4141;
+}
+.detailPage .leaderboardWrapper .colorChallengedDefault {
+    color: #ac4141;
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedDefault {
+    color: #ac4141;
+}
+.detailPage .leaderboardWrapper .colorFailedDefault {
+    color: #ac4141;
+    font-style: italic!important;
+}
+/**** Java language ****/
+.detailPage .leaderboardWrapper .colorSubmittedJava {
+    color: rgb(0, 255, 0);
+}
+.detailPage .leaderboardWrapper .colorChallengedJava {
+    color: rgb(0, 255, 0);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedJava {
+    color: rgb(0, 255, 0);
+}
+.detailPage .leaderboardWrapper .colorFailedJava {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** CPP language ****/
+.detailPage .leaderboardWrapper .colorSubmittedCpp {
+    color: rgb(255, 155, 153);
+}
+.detailPage .leaderboardWrapper .colorChallengedCpp {
+    color: rgb(255, 155, 153);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedCpp {
+    color: rgb(255, 155, 153);
+}
+.detailPage .leaderboardWrapper .colorFailedCpp {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** C# language ****/
+.detailPage .leaderboardWrapper .colorSubmittedCsharp {
+    color: rgb(102, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedCsharp {
+    color: rgb(102, 102, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedCsharp {
+    color: rgb(102, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedCsharp {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}/**** VB language ****/
+.detailPage .leaderboardWrapper .colorSubmittedVB {
+    color: rgb(129, 217, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedVB {
+    color: rgb(129, 217, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedVB {
+    color: rgb(129, 217, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedVB {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** Python language ****/
+.detailPage .leaderboardWrapper .colorSubmittedPython {
+    color: rgb(255, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedPython {
+    color: rgb(255, 102, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedPython {
+    color: rgb(255, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedPython {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+
+.detailPage .leaderboardWrapper .colorPending {
     color: #2c8236;
 }
 .detailPage .leaderboardWrapper .colorCompiled {
     color: #f99800;
-}
-.detailPage .leaderboardWrapper .colorChallenged,
-.detailPage .leaderboardWrapper .colorFailed {
-    color: #ac4141;
 }
 .detailPage .leaderboardWrapper .colorOpened {
     color: #316f99;
@@ -648,6 +733,7 @@ footer .right .sponsorLogo {
 .detailPage .leaderboardWrapper .colorUnopened {
     color: #5e676a;
 }
+
 .body .ngsb-wrap .ngsb-scrollbar .ngsb-thumb-pos .ngsb-thumb {
     background: #0999d1;
 }

--- a/app/css/orange/orangeTheme.css
+++ b/app/css/orange/orangeTheme.css
@@ -772,17 +772,101 @@ footer .left>span {
 .detailPage .table>tbody>tr>td>.rating {
     color: #656565;
 }
-.detailPage .leaderboardWrapper .colorPassed,
-.detailPage .leaderboardWrapper .colorPending,
-.detailPage .leaderboardWrapper .colorSubmitted {
+/**** Default language ****/
+.detailPage .leaderboardWrapper .colorSubmittedDefault {
+    color: #ac4141;
+}
+.detailPage .leaderboardWrapper .colorChallengedDefault {
+    color: #ac4141;
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedDefault {
+    color: #ac4141;
+}
+.detailPage .leaderboardWrapper .colorFailedDefault {
+    color: #ac4141;
+    font-style: italic!important;
+}
+/**** Java language ****/
+.detailPage .leaderboardWrapper .colorSubmittedJava {
+    color: rgb(0, 255, 0);
+}
+.detailPage .leaderboardWrapper .colorChallengedJava {
+    color: rgb(0, 255, 0);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedJava {
+    color: rgb(0, 255, 0);
+}
+.detailPage .leaderboardWrapper .colorFailedJava {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** CPP language ****/
+.detailPage .leaderboardWrapper .colorSubmittedCpp {
+    color: rgb(255, 155, 153);
+}
+.detailPage .leaderboardWrapper .colorChallengedCpp {
+    color: rgb(255, 155, 153);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedCpp {
+    color: rgb(255, 155, 153);
+}
+.detailPage .leaderboardWrapper .colorFailedCpp {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** C# language ****/
+.detailPage .leaderboardWrapper .colorSubmittedCsharp {
+    color: rgb(102, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedCsharp {
+    color: rgb(102, 102, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedCsharp {
+    color: rgb(102, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedCsharp {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}/**** VB language ****/
+.detailPage .leaderboardWrapper .colorSubmittedVB {
+    color: rgb(129, 217, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedVB {
+    color: rgb(129, 217, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedVB {
+    color: rgb(129, 217, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedVB {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+/**** Python language ****/
+.detailPage .leaderboardWrapper .colorSubmittedPython {
+    color: rgb(255, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorChallengedPython {
+    color: rgb(255, 102, 255);
+    font-style: italic!important;
+}
+.detailPage .leaderboardWrapper .colorPassedPython {
+    color: rgb(255, 102, 255);
+}
+.detailPage .leaderboardWrapper .colorFailedPython {
+    color: rgb(255, 0, 51);
+    font-style: italic!important;
+}
+
+.detailPage .leaderboardWrapper .colorPending {
     color: #2c8236;
 }
 .detailPage .leaderboardWrapper .colorCompiled {
     color: #f99800;
-}
-.detailPage .leaderboardWrapper .colorChallenged,
-.detailPage .leaderboardWrapper .colorFailed {
-    color: #ac4141;
 }
 .detailPage .leaderboardWrapper .colorOpened {
     color: #ff8a00;
@@ -790,6 +874,7 @@ footer .left>span {
 .detailPage .leaderboardWrapper .colorUnopened {
     color: #5e676a;
 }
+
 .filterPanel .contentWrapper .filterInput:focus {
     color: #333;
 }

--- a/app/js/controllers/userContestCtrl.js
+++ b/app/js/controllers/userContestCtrl.js
@@ -11,8 +11,11 @@
  * - Updated to retrieve divisionID based on roomID and roundID.
  * - Updated to remove divisionID from the state params.
  *
- * @author amethystlei
- * @version 1.2
+ * Changes in version 1.3 (Module Assembly - Web Arena UI - Division Summary):
+ * - Added isDivisionActive to check if the division is active.
+ *
+ * @author amethystlei, dexy
+ * @version 1.3
  */
 'use strict';
 /*global module, angular*/
@@ -29,8 +32,8 @@ var helper = require('../helper');
  *
  * @type {*[]}
  */
-var userContestCtrl = ['$scope', '$rootScope', '$stateParams', '$state', 'socket',
-    function ($scope, $rootScope, $stateParams, $state, socket) {
+var userContestCtrl = ['$scope', '$rootScope', '$stateParams', '$state', 'socket', 'appHelper',
+    function ($scope, $rootScope, $stateParams, $state, socket, appHelper) {
         function setContest(data) {
             $scope.contest = data;
             // rebuild the contest schedule when phase data updated
@@ -53,7 +56,7 @@ var userContestCtrl = ['$scope', '$rootScope', '$stateParams', '$state', 'socket
                 $scope.divisionID = room.divisionID;
             }
         });
-
+        $scope.isDivisionActive = appHelper.isDivisionActive;
         /**
          * Init with contest.
          *

--- a/app/js/controllers/userContestDetailCtrl.js
+++ b/app/js/controllers/userContestDetailCtrl.js
@@ -11,8 +11,25 @@
  * - Added the navigation for viewing code.
  * - Removed unnecessary $state injection as it is exposed by $rootScope.
  *
- * @author amethystlei
- * @version 1.2
+ * Changes in version 1.3 (Module Assembly - Web Arena UI - Division Summary):
+ * - Added $timeout, socket and $window.
+ * - Added closeDivSummary, closeLastDivSummary, openDivSummary, getDivSummary,
+ *   updateDivSummary, updateRoomSummary to handle retrieving and updating division summary.
+ * - Added listeners for UpdateCoderComponentResponse, UpdateCoderPointsResponse,
+ *   CreateChallengeTableResponse events to handle division summary update.
+ * - Added getLeaderRoomClass to $scope to handle room leader class.
+ * - Added isDivisionActive to scope to check if division is active (has problems).
+ * - Updated getCurrentLeaderboard to handle 'divOne' and 'divTwo' views.
+ * - Added $window.onbeforeunload and $scope.$on('destroy') listeners to close
+ *   division summary on page leaving
+ * - Updated divOneKeys and divTwoKeys to handle real data.
+ * - Updated setViewOn to open division summary and retrieve real data.
+ * - Updated getStatusColor to include language id for color selection.
+ * - Updated viewCode to include the room of the coder and not the current room
+ *   when opening the problem.
+ *
+ * @author amethystlei, dexy
+ * @version 1.3
  */
 'use strict';
 /*jshint -W097*/
@@ -31,7 +48,7 @@ var helper = require('../helper');
  *
  * @type {*[]}
  */
-var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location', function ($scope, $stateParams, $rootScope, $location) {
+var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location', '$timeout', 'socket', '$window', 'appHelper', function ($scope, $stateParams, $rootScope, $location, $timeout, socket, $window, appHelper) {
     /**
      * Check if the client suppports touch screen.
      *
@@ -114,6 +131,185 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
         return val;
     }
 
+    var // qtip here
+        // use qtip to create a filter panel
+        filter = $('.filterToggle'),
+        lbFilter = $('#leaderboardFilter'),
+        challengeFilter = $('#challengeFilter'),
+        challengerFilter = $('#challengerFilter'),
+        ldrbrdTimeoutPromise,
+        /**
+         * Close the division summary.
+         *
+         * @param roundID the round id
+         * @param divisionID the division id
+         */
+        closeDivSummary = function (roundID, divisionID) {
+            if (angular.isDefined($rootScope.lastDivSummary)) {
+                socket.emit(helper.EVENT_NAME.CloseDivSummaryRequest, {
+                    roundID: roundID,
+                    divisionID: divisionID
+                });
+            }
+        },
+        /**
+         * Close the last opened division summary.
+         */
+        closeLastDivSummary = function () {
+            if (angular.isDefined($rootScope.lastDivSummary)) {
+                closeDivSummary($rootScope.lastDivSummary.roundID, $rootScope.lastDivSummary.divisionID);
+            }
+            $rootScope.lastDivSummary = undefined;
+        },
+        /**
+         * Open the division summary.
+         *
+         * @param roundID the round id
+         * @param divisionID the division id
+         */
+        openDivSummary = function (roundID, divisionID) {
+            socket.emit(helper.EVENT_NAME.DivSummaryRequest, {
+                roundID: roundID,
+                divisionID : divisionID
+            });
+            $rootScope.lastDivSummary = {
+                roundID: roundID,
+                divisionID: divisionID
+            };
+        },
+        /**
+         * Get the division summary.
+         * It is first sending close div summary for the summary we want to open.
+         * NOTE: This is the behavior of the Arena applet.
+         *
+         * @param roundID the round id
+         * @param divisionID the division id
+         */
+        getDivSummary = function (roundID, divisionID) {
+            if (angular.isDefined($rootScope.lastDivSummary) && angular.isDefined(angular.isDefined($rootScope.lastDivSummary.roundID))
+                    && angular.isDefined($rootScope.lastDivSummary.divisionID)
+                    && $rootScope.lastDivSummary.roundID === roundID && $rootScope.lastDivSummary.divisionID === divisionID) {
+                return;
+            }
+            closeLastDivSummary();
+            $scope.currentlyLoaded = 0;
+            $scope.totalLoading = 0;
+            $scope.isDivLoading = true;
+            $scope.leaderboard = [];
+            angular.forEach($rootScope.roundData[roundID].coderRooms, function (coderRoom) {
+                if (coderRoom.divisionID === divisionID && coderRoom.roundID === roundID) {
+                    coderRoom.isLoading = true;
+                    $scope.totalLoading += 1;
+                }
+            });
+            if ($scope.totalLoading === 0) {
+                $scope.isDivLoading = false;
+            }
+            closeDivSummary(roundID, divisionID);
+            $timeout(function () {
+                openDivSummary(roundID, divisionID);
+            }, helper.DIVSUMMARYREQUEST_TIMEGAP);
+        },
+        /**
+         * Update the division summary
+         *
+         * @param roundID the round id
+         * @param divisionID the division id
+         */
+        updateDivSummary = function (roundID, divisionID) {
+            var il;
+            $scope.leaderboard = [];
+            if (angular.isDefined($rootScope.roundData) && angular.isDefined($rootScope.roundData[roundID])
+                    && angular.isDefined($rootScope.roundData[roundID].coderRooms)) {
+                angular.forEach($rootScope.roundData[roundID].coderRooms, function (coderRoom) {
+                    if (coderRoom.divisionID === divisionID && coderRoom.roundID === roundID &&
+                            angular.isDefined($rootScope.roomData[coderRoom.roomID])) {
+                        coderRoom.isLoading = false;
+                        angular.forEach($rootScope.roomData[coderRoom.roomID].coders, function (coder) {
+                            coder.roomID = coderRoom.roomID;
+                        });
+                        $scope.leaderboard = $scope.leaderboard.concat($rootScope.roomData[coderRoom.roomID].coders);
+                    }
+                });
+            }
+            if ($scope.leaderboard.length > 0) {
+                $scope.leaderboard.sort(function (coderA, coderB) {
+                    return coderB.totalPoints - coderA.totalPoints;
+                });
+                $scope.leaderboard[0].divPlace = 1;
+                for (il = 1; il < $scope.leaderboard.length; il += 1) {
+                    if ($scope.leaderboard[il].totalPoints === $scope.leaderboard[il - 1].totalPoints) {
+                        $scope.leaderboard[il].divPlace = $scope.leaderboard[il - 1].divPlace;
+                    } else {
+                        $scope.leaderboard[il].divPlace = (il + 1);
+                    }
+                }
+            }
+            $scope.isDivLoading = false;
+            $scope.currentlyLoaded = 0;
+            angular.forEach($rootScope.roundData[roundID].coderRooms, function (coderRoom) {
+                if (coderRoom.divisionID === divisionID && coderRoom.roundID === roundID) {
+                    if (coderRoom.isLoading) {
+                        $scope.currentlyLoaded += 1;
+                        $scope.isDivLoading = true;
+                    }
+                }
+            });
+            $timeout.cancel(ldrbrdTimeoutPromise);
+            ldrbrdTimeoutPromise = $timeout(function () {
+                $scope.$broadcast('rebuild:leaderboardTable');
+            }, helper.LEADERBOARD_TABLE_REBUILT_TIMEGAP);
+        },
+        /**
+         * Update the room summary.
+         * It only checks if the current opened division summary (if any) should be updated
+         * if the room with roomID is updated. It then calls updateDivSummary.
+         *
+         * @param roomID the room id
+         */
+        updateRoomSummary = function (roomID) {
+            var updatedDivSummary = false;
+            if ($scope.viewOn !== 'room') {
+                if (angular.isDefined($rootScope.roundData) && angular.isDefined($rootScope.roundData[$stateParams.contestId])
+                        && angular.isDefined($rootScope.roundData[$stateParams.contestId].coderRooms)) {
+                    angular.forEach($rootScope.roundData[$stateParams.contestId].coderRooms, function (coderRoom) {
+                        if (coderRoom.roomID === roomID && coderRoom.divisionID === helper.VIEW_ID[$scope.viewOn] && coderRoom.roundID === Number($stateParams.contestId)) {
+                            updatedDivSummary = true;
+                        }
+                    });
+                }
+            }
+            if (updatedDivSummary) {
+                updateDivSummary(Number($stateParams.contestId), helper.VIEW_ID[$scope.viewOn]);
+            }
+        },
+        /**
+         * Close the last opened division summary on leaving the page.
+         */
+        onLeavingContestDetailPage = function () {
+            closeLastDivSummary();
+        };
+    /*jslint unparam:true*/
+    $scope.$on(helper.EVENT_NAME.UpdateCoderComponentResponse, function (event, data) {
+        updateRoomSummary(data.roomID);
+    });
+    $scope.$on(helper.EVENT_NAME.UpdateCoderPointsResponse, function (event, data) {
+        updateRoomSummary(data.roomID);
+    });
+    $scope.$on(helper.EVENT_NAME.CreateChallengeTableResponse, function (event, data) {
+        updateRoomSummary(data.roomID);
+    });
+    /*jslint unparam:false*/
+
+    /**
+     * Gets the leader room class.
+     *
+     * @param roomPlace the rank in the room of the competitor
+     * @return 'roomLeader' class if the competitor is the first in the room, otherwise returns ''
+     */
+    $scope.getLeaderRoomClass = function (roomPlace) {
+        return roomPlace === 1 ? 'roomLeader' : '';
+    };
     $scope.contest = $rootScope.roundData[$stateParams.contestId];
     $scope.divisionID = $stateParams.divisionId;
     $scope.roomID = $rootScope.currentRoomInfo.roomID;
@@ -138,7 +334,7 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
     $scope.boards = [[], []];
     $scope.leaderboard = [];
     $scope.showBy = 'points';
-
+    $scope.isDivisionActive = appHelper.isDivisionActive;
     /**
      * Get the selected leader board.
      *
@@ -148,14 +344,18 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
         if ($scope.viewOn === 'room') {
             return $rootScope.roomData[$scope.roomID].coders;
         }
-        // For now it is set to empty for division summary.
         if ($scope.viewOn === 'divOne') {
-            return [];
+            return $scope.leaderboard;
         }
         if ($scope.viewOn === 'divTwo') {
-            return [];
+            return $scope.leaderboard;
         }
     };
+
+    // Closes the opened division summary on page leaving.
+    $window.onbeforeunload = onLeavingContestDetailPage;
+    $scope.$on("$destroy", onLeavingContestDetailPage);
+    $scope.isDivLoading = false;
 
     $scope.roomKeys = {
         challengerKey: '-points',
@@ -180,7 +380,7 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
     $scope.divOneKeys = {
         challengerKey: '-points',
         challengeKey: '-date',
-        leaderboardKey: '-results[0].score',
+        leaderboardKey: '-totalPoints',
         challengerFilterKey: 'all',
         challengeFilterKey: 'all',
         lbFilterKey: 'all',
@@ -193,13 +393,13 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
             }
         },
         lbFilter : {
-            handle: ''
+            userName: ''
         }
     };
     $scope.divTwoKeys = {
         challengerKey: '-points',
         challengeKey: '-date',
-        leaderboardKey: '-results[0].score',
+        leaderboardKey: '-totalPoints',
         challengerFilterKey: 'all',
         challengeFilterKey: 'all',
         lbFilterKey: 'all',
@@ -212,7 +412,7 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
             }
         },
         lbFilter : {
-            handle: ''
+            userName: ''
         }
     };
     // get sort Key according to view
@@ -240,6 +440,14 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
      * @param view can be 'room', 'divOne', 'divTwo'
      */
     $scope.setViewOn = function (view) {
+        var divID = helper.VIEW_ID[view];
+        if (view !== 'room') {
+            getDivSummary($scope.contest.roundID, divID);
+        } else {
+            closeLastDivSummary();
+            $scope.leaderboard = [];
+            $scope.isDivLoading = false;
+        }
         $scope.viewOn = view;
         rebuildScrollbars();
     };
@@ -281,10 +489,17 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
      * Get the css class for the color of the component status.
      *
      * @param status the status
+     * @param languageID the id of the language
      * @returns {string} the css class name
      */
-    $scope.getStatusColor = function (status) {
-        return 'color' + helper.CODER_PROBLEM_STATUS_NAME[status];
+    $scope.getStatusColor = function (status, languageID) {
+        var statusName = helper.CODER_PROBLEM_STATUS_NAME[status],
+            className = 'color' + statusName;
+        if (statusName === 'Submitted' || statusName === 'Challenged'
+                || statusName === 'Failed' || statusName === 'Passed') {
+            className += helper.LANGUAGE_NAME[languageID];
+        }
+        return className;
     };
 
     /**
@@ -331,7 +546,7 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
      * Check if the code of the component can be viewed by the user.
      *
      * @params component the component
-     * @returns {boolean} true if the component can be viewed 
+     * @returns {boolean} true if the component can be viewed
      */
     $scope.isViewable = function (component) {
         // cannot view when phase is not challenge or after.
@@ -401,12 +616,6 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
         }
     };
 
-    // qtip here
-    // use qtip to create a filter panel
-    var filter = $('.filterToggle'),
-        lbFilter = $('#leaderboardFilter'),
-        challengeFilter = $('#challengeFilter'),
-        challengerFilter = $('#challengerFilter');
     filter.qtip({
         content: {
             text: ''
@@ -509,6 +718,10 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
             } else {
                 $scope.getKeys(viewOn).lbFilter.userName = '';
             }
+            $timeout.cancel(ldrbrdTimeoutPromise);
+            ldrbrdTimeoutPromise = $timeout(function () {
+                $scope.$broadcast('rebuild:leaderboardTable');
+            }, helper.LEADERBOARD_TABLE_REBUILT_TIMEGAP);
         } else if (panel === 'challenge') {
             challengeFilter.qtip('api').toggle(false);
             if ($scope.getKeys(viewOn).challengeFilterKey === 'specific') {
@@ -552,12 +765,13 @@ var userContestDetailCtrl = ['$scope', '$stateParams', '$rootScope', '$location'
      * @param {number} componentId
      */
     $scope.viewCode = function (coder, componentId) {
+        var roomID = ($scope.viewOn === 'room') ? $scope.roomID : coder.roomID;
         if ($scope.contest.phaseData.phaseType >= helper.PHASE_TYPE_ID.ChallengePhase) {
             $scope.$state.go(helper.STATE_NAME.ViewCode, {
                 roundId: $stateParams.contestId,
                 divisionId: $scope.divisionID,
                 componentId: componentId,
-                roomId: $scope.roomID,
+                roomId: roomID,
                 defendant: coder.userName
             });
         }

--- a/app/js/factories.js
+++ b/app/js/factories.js
@@ -19,8 +19,11 @@
  * Changes in version 1.3 (Module Assembly - Web Arena UI - Phase I Bug Fix):
  * - Updated present and past phrases for verbs in appHelper.getPhaseTime.
  *
+ * Changes in version 1.4 (Module Assembly - Web Arena UI - Division Summary)
+ * - Updated appHelper to include isDivisionActive.
+ *
  * @author tangzx, dexy, amethystlei
- * @version 1.3
+ * @version 1.4
  */
 'use strict';
 var config = require('./config');
@@ -130,15 +133,15 @@ factories.notificationService = ['$timeout', '$http', 'sessionHelper', function 
 }];
 
 factories.appHelper = [function () {
-    var helper = {};
+    var retHelper = {};
 
     // return an empty array of fixed length
-    helper.range = function (num) {
+    retHelper.range = function (num) {
         return new [].constructor(num);
     };
 
     // Checks if a string is not null nor empty.
-    helper.isStringNotNullNorEmpty = function (s) {
+    retHelper.isStringNotNullNorEmpty = function (s) {
         return s && s.length > 0;
     };
 
@@ -146,7 +149,7 @@ factories.appHelper = [function () {
     // Used in contest schedule displaying.
     // Usually we have start time and end time.
     // When start time is not available, end time should take its place.
-    helper.getPhaseTime = function (phase, id, currentPhase) {
+    retHelper.getPhaseTime = function (phase, id, currentPhase) {
         function displayStart() {
             return phase.phaseType <= currentPhase.phaseType ? 'Started' : 'Starts';
         }
@@ -154,21 +157,21 @@ factories.appHelper = [function () {
             return phase.phaseType < currentPhase.phaseType ? 'Ended' : 'Ends';
         }
         if (id === 0) {
-            if (helper.isStringNotNullNorEmpty(phase.start)) {
+            if (retHelper.isStringNotNullNorEmpty(phase.start)) {
                 return {
                     key: displayStart(),
                     value: phase.start
                 };
             }
-            if (helper.isStringNotNullNorEmpty(phase.end)) {
+            if (retHelper.isStringNotNullNorEmpty(phase.end)) {
                 return {
                     key: displayEnd(),
                     value: phase.end
                 };
             }
         } else if (id === 1) {
-            if (helper.isStringNotNullNorEmpty(phase.start) &&
-                    helper.isStringNotNullNorEmpty(phase.end)) {
+            if (retHelper.isStringNotNullNorEmpty(phase.start) &&
+                    retHelper.isStringNotNullNorEmpty(phase.end)) {
                 return {
                     key: displayEnd(),
                     value: phase.end
@@ -179,7 +182,7 @@ factories.appHelper = [function () {
     };
 
     // parse the string formatted as 'Fri Feb 6, 4:02 PM EST' to date object.
-    helper.parseDate = function (s) {
+    retHelper.parseDate = function (s) {
         var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
             arr = s.split(' '),
             month = (function (monthAbbr) {
@@ -212,7 +215,7 @@ factories.appHelper = [function () {
         return date;
     };
 
-    helper.clickOnTarget = function (clicked, id, stepLimit) {
+    retHelper.clickOnTarget = function (clicked, id, stepLimit) {
         if (!clicked) {
             return false;
         }
@@ -226,15 +229,30 @@ factories.appHelper = [function () {
         return false;
     };
 
-    helper.stripPx = function (str) {
+    retHelper.stripPx = function (str) {
         return parseInt(str.substring(0, str.length - 2), 10);
     };
 
-    helper.getRenderedHeight = function (el) {
-        return helper.stripPx(angular.element(el).css('height'));
+    retHelper.getRenderedHeight = function (el) {
+        return retHelper.stripPx(angular.element(el).css('height'));
     };
 
-    return helper;
+    /**
+     * Checks if the division is active (has non empty set of problems).
+     *
+     * @param view the current opened view
+     * @return true if the division is active, false otherwise
+     */
+    retHelper.isDivisionActive = function (contest, view) {
+        var divisionID = helper.VIEW_ID[view];
+        if (angular.isUndefined(contest.problems) || angular.isUndefined(contest.problems[divisionID])
+                || contest.problems[divisionID].length === 0) {
+            return false;
+        }
+        return true;
+    };
+
+    return retHelper;
 }];
 
 factories.tcTimeService = ['$rootScope', '$timeout', '$filter', 'socket', function ($rootScope, $timeout, $filter, socket) {

--- a/app/js/helper.js
+++ b/app/js/helper.js
@@ -37,8 +37,12 @@
  * Changes in version 1.8 (Module Assembly - Web Arena UI - Phase I Bug Fix):
  * - Updated PHASE_NAME for System Test.
  *
+ * Changes in version 1.9 (Module Assembly - Web Arena UI - Division Summary):
+ * - Added CloseDivSummaryRequest and DivSummaryRequest.
+ * - Added LANGUAGE_NAME, VIEW_ID, DIVSUMMARYREQUEST_TIMEGAP constants.
+ *
  * @author tangzx, amethystlei, dexy
- * @version 1.8
+ * @version 1.9
  */
 
 module.exports = {
@@ -62,6 +66,7 @@ module.exports = {
         ChallengeRequest: 'ChallengeRequest',
         ChatRequest: 'ChatRequest',
         CloseProblemRequest: 'CloseProblemRequest',
+        CloseDivSummaryRequest: 'CloseDivSummaryRequest',
         CoderInfoRequest: 'CoderInfoRequest',
         CompileRequest: 'CompileRequest',
         EnterRequest: 'EnterRequest',
@@ -72,6 +77,7 @@ module.exports = {
         LogoutRequest: 'LogoutRequest',
         MoveRequest: 'MoveRequest',
         OpenComponentForCodingRequest: 'OpenComponentForCodingRequest',
+        DivSummaryRequest: 'DivSummaryRequest',
         RegisterInfoRequest: 'RegisterInfoRequest',
         RegisterRequest: 'RegisterRequest',
         RegisterUsersRequest: 'RegisterUsersRequest',
@@ -184,6 +190,16 @@ module.exports = {
         '160': 'Failed',
         '150': 'Passed'
     },
+    // Represents the language name.
+    LANGUAGE_NAME: {
+        '0': 'Default',
+        '1': 'Java',
+        '2': 'Default',
+        '3': 'Cpp',
+        '4': 'Csharp',
+        '5': 'VB',
+        '6': 'Python'
+    },
 
     // the timeout of request
     REQUEST_TIME_OUT: 10 * 1000,
@@ -195,9 +211,10 @@ module.exports = {
     INNACTIVITY_TIMEOUT: 90 * 1000,
     // default value for keep alive timeout
     KEEP_ALIVE_TIMEOUT: 30 * 1000,
-
     // maximum characters of a message can be sent in chat rooms.
     MAX_CHAT_LENGTH: 256,
+    // Time gap between two leaderboad table rebuildings
+    LEADERBOARD_TABLE_REBUILT_TIMEGAP: 3000,
 
     // pop up titles
     POP_UP_TITLES: {
@@ -271,5 +288,15 @@ module.exports = {
     COMPILE_RESULTS_TYPE_ID: {
         FAILED: 0,
         SUCCEEDED: 1
-    }
+    },
+
+    // Mapping from view name to its id.
+    VIEW_ID: {
+        'room': -1,
+        'divOne': 1,
+        'divTwo': 2
+    },
+
+    // The timeout between two consecutive CloseDivSummaryRequest and DivSummaryRequest.
+    DIVSUMMARYREQUEST_TIMEGAP: 100
 };

--- a/app/js/resolvers.js
+++ b/app/js/resolvers.js
@@ -33,8 +33,12 @@
  * - Removed weekly information from date format (DATE_FORMAT).
  * - Updated the handler of RoundScheduleResponse to use $rootScope.timeZone instead of $rootScope.timezone.
  *
+ * Changes in version 1.7 (Module Assembly - Web Arena UI - Division Summary):
+ * - Added $broadcast to the $rootScope of CreateChallengeTableResponse and
+ *   UpdateCoderComponentResponse events.
+ *
  * @author amethystlei, dexy
- * @version 1.6
+ * @version 1.7
  */
 ///////////////
 // RESOLVERS //
@@ -348,6 +352,7 @@ resolvers.finishLogin = ['$rootScope', '$q', '$state', '$filter', 'cookies', 'se
         }
         $rootScope.roomData[data.roomID] = data;
         updateCoderPlacement($rootScope.roomData[data.roomID].coders);
+        $rootScope.$broadcast(helper.EVENT_NAME.CreateChallengeTableResponse, data);
     });
 
     // handle update coder points response
@@ -362,6 +367,7 @@ resolvers.finishLogin = ['$rootScope', '$q', '$state', '$filter', 'cookies', 'se
             }
         });
         updateCoderPlacement($rootScope.roomData[data.roomID].coders);
+        $rootScope.$broadcast(helper.EVENT_NAME.UpdateCoderPointsResponse, data);
     });
 
     // handle update coder component response
@@ -380,6 +386,7 @@ resolvers.finishLogin = ['$rootScope', '$q', '$state', '$filter', 'cookies', 'se
             }
         });
         updateCoderPlacement($rootScope.roomData[data.roomID].coders);
+        $rootScope.$broadcast(helper.EVENT_NAME.UpdateCoderComponentResponse, data);
     });
 
     // handle the end sync response for initialization when logging in

--- a/app/partials/user.contest.detail.html
+++ b/app/partials/user.contest.detail.html
@@ -21,8 +21,8 @@
                                 <div class="tabs">
                                     <ul class="nav nav-tabs hidden-xs">
                                         <li data-ng-class="{'textActive': viewOn=='room'}" data-ng-click="setViewOn('room')">Room</li>
-                                        <li data-ng-class="{'textActive': viewOn=='divOne'}" data-ng-click="setViewOn('divOne')">Division I</li>
-                                        <li data-ng-class="{'textActive': viewOn=='divTwo'}" data-ng-click="setViewOn('divTwo')">Division II</li>
+                                        <li data-ng-show="isDivisionActive(contest, 'divOne')" data-ng-class="{'textActive': viewOn=='divOne'}" data-ng-click="setViewOn('divOne')">Division I</li>
+                                        <li data-ng-show="isDivisionActive(contest, 'divTwo')" data-ng-class="{'textActive': viewOn=='divTwo'}" data-ng-click="setViewOn('divTwo')">Division II</li>
                                     </ul>
                                     <!-- button and label will show when window is very narrow -->
                                     <ul class="nav altNav visible-xs">
@@ -32,8 +32,8 @@
                                             </a>
                                             <ul class="dropdown-menu">
                                                 <li data-ng-class="{'textActive': viewOn=='room'}" data-ng-click="setViewOn('room')">Room</li>
-                                                <li data-ng-class="{'textActive': viewOn=='divOne'}" data-ng-click="setViewOn('divOne')">Division I</li>
-                                                <li data-ng-class="{'textActive': viewOn=='divTwo'}" data-ng-click="setViewOn('divTwo')">Division II</li>
+                                                <li data-ng-class="{'textActive': viewOn=='divOne'}" data-ng-show="isDivisionActive(contest, 'divOne')" data-ng-click="setViewOn('divOne')">Division I</li>
+                                                <li data-ng-class="{'textActive': viewOn=='divTwo'}" data-ng-show="isDivisionActive(contest, 'divTwo')" data-ng-click="setViewOn('divTwo')">Division II</li>
                                             </ul>
                                         </li>
                                     </ul>
@@ -47,7 +47,7 @@
                                         <div class="scroll" data-ng-scrollbar data-scroll-top data-rebuild-on-resize data-rebuild-on="rebuild:summary"><div class="innerWrapper">{{contest.divOneSummary}}</div></div>
                                         <div class="default"><div class="innerWrapper">{{contest.divOneSummary}}</div></div>
                                     </div>
-                                    <div data-ng-show="viewOn=='divTwo'" class="divTwoDiv sumDiv">
+                                    <div data-ng-show="viewOn=='divTwo'" data-ng-class="{divOneDiv: !isDivisionActive(contest, 'divOne'), divTwoDiv: isDivisionActive(contest, 'divOne')}" class="sumDiv">
                                         <div class="scroll" data-ng-scrollbar data-scroll-top data-rebuild-on-resize data-rebuild-on="rebuild:summary"><div class="innerWrapper">{{contest.divTwoSummary}}</div></div>
                                         <div class="default"><div class="innerWrapper">{{contest.divTwoSummary}}</div></div>
                                     </div>
@@ -210,7 +210,7 @@
                                             </div><!--/.innerWrapper-->
                                         </div><!-- /.tHeadDiv-->
                                         <div class="tableDiv scroll" data-ng-scrollbar data-scroll-top data-rebuild-on-resize data-rebuild-on="rebuild:challengeTable">
-                                            <div class="innerWrapper">    
+                                            <div class="innerWrapper">
                                                 <table class="table table-condensed">
                                                     <tbody>
                                                         <tr data-ng-repeat="challenge in challenges | filter: getKeys(viewOn).challengeFilter | orderBy: getKeys(viewOn).challengeKey | limitTo: showChallenges">
@@ -252,7 +252,7 @@
                         <div class="col-lg-6 col-md-6 col-sm-12 col-xs-12 rightSec" id="rSec">
                             <section class="leaderboardWrapper" id="leaderboardPanel">
                                 <div class="heading">
-                                    <h3><span data-ng-show="viewOn=='room'">Room</span><span data-ng-hide="viewOn=='room'">Division</span> Leaderboard</h3><br/>
+                                    <h3><span data-ng-show="viewOn=='room'">Room</span><span data-ng-hide="viewOn=='room'">Division</span> <span data-ng-show="viewOn=='divOne'">I</span><span data-ng-show="viewOn=='divTwo'">II</span> Leaderboard<span data-ng-show="isDivLoading"> (Loading... <span>{{currentlyLoaded}}/{{totalLoading}}</span>)</span></h3><br/>
                                     <div class="filterArea" data-ng-show="registrationFinished()">
                                         <a id="leaderboardFilter" data-ng-click="checkFilter(viewOn, 'leaderboard')" class="filterToggle">Filter</a>
                                         <div>
@@ -286,17 +286,20 @@
                                     <a data-ng-click="toggleExpand('leaderboardPanel', 'rSec', 'lSec')" class="expandIcon"></a>
                                 </div><!--/.heading-->
                                 <p data-ng-show="!registrationFinished()">The leaderboard is not ready.</p>
-                                <div class="tableWrapper" data-ng-show="registrationFinished()">
+                                <div class="tableWrapper" data-ng-show="registrationFinished()" data-rebuild-on="rebuild:leaderboardTable">
                                     <div class="tHeadDiv" data-ng-class="{moreProblemTbl:contest.problems[divisionID].length>3,normal:contest.problems[divisionID].length<=3}">
                                         <div class="innerWrapper">
                                             <table class="table table-condensed">
                                                 <thead>
                                                     <tr>
-                                                        <th class="col1 sortableHeading" data-ng-hide="viewOn=='room'" data-ng-click="toggleSortKey(viewOn, 'leaderboard', 'roomId')">
-                                                            Room #<span><span data-ng-show="getKeys(viewOn).leaderboardKey=='roomId' || getKeys(viewOn).leaderboardKey=='-roomId'" data-ng-class="{descArrow:getKeys(viewOn).leaderboardKey=='-roomId',ascArrow:getKeys(viewOn).leaderboardKey=='roomId'}" class="arrow"></span></span>
+                                                        <th class="col1 sortableHeading" data-ng-hide="viewOn=='room'" data-ng-click="toggleSortKey(viewOn, 'leaderboard', 'divPlace')">
+                                                            Place<span><span data-ng-show="getKeys(viewOn).leaderboardKey=='divPlace' || getKeys(viewOn).leaderboardKey=='-divPlace'" data-ng-class="{descArrow:getKeys(viewOn).leaderboardKey=='-divPlace',ascArrow:getKeys(viewOn).leaderboardKey=='divPlace'}" class="arrow"></span></span>
                                                         </th>
                                                         <th class="col1 sortableHeading" data-ng-show="viewOn=='room'" data-ng-click="toggleSortKey(viewOn, 'leaderboard', 'roomPlace')">
                                                             Place<span><span data-ng-show="getKeys(viewOn).leaderboardKey=='roomPlace' || getKeys(viewOn).leaderboardKey=='-roomPlace'" data-ng-class="{descArrow:getKeys(viewOn).leaderboardKey=='-roomPlace',ascArrow:getKeys(viewOn).leaderboardKey=='roomPlace'}" class="arrow"></span></span>
+                                                        </th>
+                                                        <th class="colR sortableHeading" data-ng-click="toggleSortKey(viewOn, 'leaderboard', 'userRating')">
+                                                            <span>R<span data-ng-show="getKeys(viewOn).leaderboardKey=='userRating' || getKeys(viewOn).leaderboardKey=='-userRating'" data-ng-class="{descArrow:getKeys(viewOn).leaderboardKey=='-userRating',ascArrow:getKeys(viewOn).leaderboardKey=='userRating'}" class="arrow"></span></span>
                                                         </th>
                                                         <th class="col2 sortableHeading" data-ng-click="toggleSortKey(viewOn, 'leaderboard', 'userName')">
                                                             Handle<span><span data-ng-show="getKeys(viewOn).leaderboardKey=='userName' || getKeys(viewOn).leaderboardKey=='-userName'" data-ng-class="{descArrow:getKeys(viewOn).leaderboardKey=='-userName',ascArrow:getKeys(viewOn).leaderboardKey=='userName'}" class="arrow"></span></span>
@@ -312,20 +315,23 @@
                                             </table>
                                         </div><!--/.innerWrapper-->
                                     </div><!--/.tHeadDiv-->
-                                    <div class="tableDiv scroll" data-ng-scrollbar data-scroll-top data-rebuild-on-resize data-rebuild-on="rebuild:leaderboardTable" data-ng-class="{moreProblemTbl:contest.problems[divisionID].length>3,normal:contest.problems[divisionID].length<=3}">
+                                    <div class="tableDiv scroll" data-ng-scrollbar data-scroll-top data-rebuild-on-resize data-ng-class="{moreProblemTbl:contest.problems[divisionID].length>3,normal:contest.problems[divisionID].length<=3}">
                                         <div class="innerWrapper">
                                             <table class="table table-condensed">
                                                 <tbody>
                                                      <tr data-ng-repeat="coder in getCurrentLeaderboard() | filter: getKeys(viewOn).lbFilter | orderBy: getKeys(viewOn).leaderboardKey">
-                                                        <td class="col1">{{viewOn=='room' ? coder.roomPlace : roomID}}</td>
-                                                        <td class="col2"><!-- avoid blank
+                                                        <td class="col1">{{viewOn=='room' ? coder.roomPlace : coder.divPlace}}</td>
+                                                        <td class="colR" data-ng-click="showCoderInfo(coder.userName, coder.userType);"><!-- avoid blank
                                                             --><!-- avoid blank
-                                                            --><span class="name {{getRatingClass(coder.userRating)}}"><span data-rating-indicator="{{coder.userRating}}" data-username="{{coder.userName}}" class="ratingIcon"></span>{{coder.userName}}</span>&nbsp;<!-- avoid blank
-                                                            --><span class="rating">({{coder.userRating}})</span>
+                                                            --><span data-rating-indicator="{{coder.userRating}}" data-username="{{coder.userName}}" class="ratingIcon"></span>
+                                                        </td>
+                                                        <td class="col2" data-ng-click="showCoderInfo(coder.userName, coder.userType);"><!-- avoid blank
+                                                            --><!-- avoid blank
+                                                            --><span class="name {{getRatingClass(coder.userRating)}} {{getLeaderRoomClass(coder.roomPlace)}}">{{coder.userName}}</span>
                                                         </td>
                                                         <td data-ng-repeat="component in coder.components track by $index" class="colProblem">
-                                                            <a data-ng-show="isViewable(component)" data-ng-click="viewCode(coder, component.componentID)"><span class="{{getStatusColor(component.status)}}">{{showResult(component, $parent.showBy)}}</span></a>
-                                                            <span data-ng-hide="isViewable(component)" class="{{getStatusColor(component.status)}}">{{showResult(component, $parent.showBy)}}</span>
+                                                            <a data-ng-show="isViewable(component)" data-ng-click="viewCode(coder, component.componentID)"><span class="{{getStatusColor(component.status, component.language)}}">{{showResult(component, $parent.showBy)}}</span></a>
+                                                            <span data-ng-hide="isViewable(component)" class="{{getStatusColor(component.status, component.language)}}">{{showResult(component, $parent.showBy)}}</span>
                                                         </td>
                                                         <td class="col6">{{formatScore(coder.totalPoints)}}</td>
                                                     </tr>
@@ -338,15 +344,18 @@
                                            <table class="table table-condensed">
                                                 <tbody>
                                                      <tr data-ng-repeat="coder in getCurrentLeaderboard() | filter: getKeys(viewOn).lbFilter | orderBy: getKeys(viewOn).leaderboardKey">
-                                                        <td class="col1">{{viewOn=='room' ? coder.roomPlace : roomID}}</td>
-                                                        <td class="col2"><!-- avoid blank 
-                                                            --><!-- avoid blank 
-                                                            --><span class="name {{getRatingClass(coder.userRating)}}"><span data-rating-indicator="{{coder.userRating}}" data-username="{{coder.userName}}" class="ratingIcon"></span>{{coder.userName}}</span>&nbsp;<!-- avoid blank 
-                                                            --><span class="rating">({{coder.userRating}})</span>
+                                                        <td class="col1">{{viewOn=='room' ? coder.roomPlace : coder.divPlace}}</td>
+                                                        <td class="colR" data-ng-click="showCoderInfo(coder.userName, coder.userType);"><!-- avoid blank
+                                                            --><!-- avoid blank
+                                                            --><span data-rating-indicator="{{coder.userRating}}" data-username="{{coder.userName}}" class="ratingIcon"></span>
+                                                        </td>
+                                                        <td class="col2" data-ng-click="showCoderInfo(coder.userName, coder.userType);"><!-- avoid blank
+                                                            --><!-- avoid blank
+                                                            --><span class="name {{getRatingClass(coder.userRating)}} {{getLeaderRoomClass(coder.roomPlace)}}">{{coder.userName}}</span>
                                                         </td>
                                                         <td data-ng-repeat="component in coder.components track by $index" class="colProblem">
-                                                            <a data-ng-show="isViewable(component)" data-ng-click=""><span class="{{getStatusColor(component.status)}}">{{showResult(component, $parent.showBy)}}</span></a>
-                                                            <span data-ng-hide="isViewable(component)" class="{{getStatusColor(component.status)}}">{{showResult(component, $parent.showBy)}}</span>
+                                                            <a data-ng-show="isViewable(component)" data-ng-click=""><span class="{{getStatusColor(component.status, component.language)}}">{{showResult(component, $parent.showBy)}}</span></a>
+                                                            <span data-ng-hide="isViewable(component)" class="{{getStatusColor(component.status, component.language)}}">{{showResult(component, $parent.showBy)}}</span>
                                                         </td>
                                                         <td class="col6">{{formatScore(coder.totalPoints)}}</td>
                                                     </tr>

--- a/app/partials/user.contest.summary.html
+++ b/app/partials/user.contest.summary.html
@@ -7,8 +7,8 @@
             <div class="tabs">
                 <ul class="nav nav-tabs hidden-xs">
                     <li data-ng-class="{'textActive': viewOn=='room'}" data-ng-click="setViewOn('room')">Room</li>
-                    <li data-ng-class="{'textActive': viewOn=='divOne'}" data-ng-click="setViewOn('divOne')">Division I</li>
-                    <li data-ng-class="{'textActive': viewOn=='divTwo'}" data-ng-click="setViewOn('divTwo')">Division II</li>
+                    <li data-ng-show="isDivisionActive(contest, 'divOne')" data-ng-class="{'textActive': viewOn=='divOne'}" data-ng-click="setViewOn('divOne')">Division I</li>
+                    <li data-ng-show="isDivisionActive(contest, 'divTwo')" data-ng-class="{'textActive': viewOn=='divTwo'}" data-ng-click="setViewOn('divTwo')">Division II</li>
                 </ul>
                 <!-- button and label will show when window is very narrow -->
                 <ul class="nav altNav visible-xs">
@@ -18,8 +18,8 @@
                         </a>
                         <ul class="dropdown-menu">
                             <li data-ng-class="{'textActive': viewOn=='room'}" data-ng-click="setViewOn('room')">Room</li>
-                            <li data-ng-class="{'textActive': viewOn=='divOne'}" data-ng-click="setViewOn('divOne')">Division I</li>
-                            <li data-ng-class="{'textActive': viewOn=='divTwo'}" data-ng-click="setViewOn('divTwo')">Division II</li>
+                            <li data-ng-show="isDivisionActive(contest, 'divOne')" data-ng-class="{'textActive': viewOn=='divOne'}" data-ng-click="setViewOn('divOne')">Division I</li>
+                            <li data-ng-show="isDivisionActive(contest, 'divTwo')" data-ng-class="{'textActive': viewOn=='divTwo'}" data-ng-click="setViewOn('divTwo')">Division II</li>
                         </ul>
                     </li>
                 </ul>
@@ -33,7 +33,7 @@
                     <div class="scroll visible-lg visible-md" data-ng-scrollbar data-rebuild-on-resize><div class="innerWrapper">{{contest.divOneSummary}}</div></div>
                     <div class="default visible-sm visible-xs"><div class="innerWrapper">{{contest.divOneSummary}}</div></div>
                 </div>
-                <div data-ng-show="viewOn=='divTwo'" class="divTwoDiv sumDiv">
+                <div data-ng-show="viewOn=='divTwo'" data-ng-class="{divOneDiv: !isDivisionActive(contest, 'divOne'), divTwoDiv: isDivisionActive(contest, 'divOne')}" class="sumDiv">
                     <div class="scroll visible-lg visible-md" data-ng-scrollbar data-rebuild-on-resize><div class="innerWrapper">{{contest.divTwoSummary}}</div></div>
                     <div class="default visible-sm visible-xs"><div class="innerWrapper">{{contest.divTwoSummary}}</div></div>
                 </div>
@@ -43,4 +43,3 @@
     </div>
     <!-- /.panel-body -->
 </div>
-    


### PR DESCRIPTION
Added support for Division Summary requests/response handling and updating division leaderboard tables.
- in userContestDetailCtrl.js added logic for handling division summaries
- in app.css/darkTheme.css/lightTheme.css/orangeTheme.css: support for rating column and support for different colors in the leaderboard table for different problem status + language combinations is added
- move handling of showCoderInfo and its response from chatAreaCtrl.js to baseCtrl.js
