### PR TITLE
Fixing background color of loading spinner

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -657,7 +657,7 @@ body a {cursor: pointer;}
     width: 180px;
     height: 40px;
     z-index: 1000;
-    background-color: #000000;
+    background-color: #1c1c1c;
     opacity: 1;
     border: 1px solid #0bbbe7;
     -webkit-border-radius: 4px;


### PR DESCRIPTION
Fixed background color of the popup to be in sync with the bg color of the spinner image (which is not quite #000000 but more like #1c1c1c)
