### PR TITLE
Improved coder placement algorithm performance

### DIFF
--- a/app/js/resolvers.js
+++ b/app/js/resolvers.js
@@ -76,9 +76,12 @@
  * Changes in version 1.18 (Module Assembly - Web Arena - Quick Fixes for Contest Management)
  * - Added handling of ChangeRoundResponse, CommandSucceededResponse, CommandFailedResponse
  *   and RoundAccessResponse events.
+ * 
+ * Changes in version 1.19 (Module Assembly - Web Arena - Coder Placement)
+ * - Fixed coder placement algorithm to improve performance from Θ(n^2) to O(nlogn)
  *
- * @author amethystlei, dexy, ananthhh, flytoj2ee
- * @version 1.18
+ * @author amethystlei, dexy, ananthhh, flytoj2ee, goodwine
+ * @version 1.19
  */
 ///////////////
 // RESOLVERS //
@@ -133,13 +136,23 @@ resolvers.finishLogin = ['$rootScope', '$q', '$state', '$filter', 'cookies', 'se
          * @param {Array} coders
          */
         updateCoderPlacement = function (coders) {
-            coders.forEach(function (item) {
-                item.roomPlace = 1;
-                coders.forEach(function (other) {
-                    if (item.userName !== other.userName && item.totalPoints < other.totalPoints) {
-                        item.roomPlace += 1;
-                    }
-                });
+            // descending order sorting by totalPoints
+            coders.sort(function(a, b){
+                if (a.totalPoints > b.totalPoints)
+                    return -1;
+                if (a.totalPoints < b.totalPoints)
+                    return 1;
+                return 0;
+            });
+            var roomPlace = 1; // coder's placement on the room.
+            var lastScore = -1; // to "freeze" roomPlace if the score is the same.
+            // assign the placement to each coder
+            coders.forEach(function(coder, index){
+                if (coder.totalPoints != lastScore) {
+                    roomPlace = index + 1;
+                    lastScore = coder.totalPoints;
+                }
+                coder.roomPlace = roomPlace;
             });
         };
     // No need to start again if user already logged in


### PR DESCRIPTION
Improved performance from Θ(n²) to O(nlogn)

Current algorithm can take a lot of time, and it times-out as described on Issue #1099

You can compare the algorithms with these gists:
- Current: https://gist.github.com/Goodwine/e719e1954aec742ea190
- Proposed: https://gist.github.com/Goodwine/5e153dc05467aa3df518

One thing to note is that the original order is lost (because the array is sorted by totalPoints), but I didn't find any place that suggested that it would break something, in any case, I could update the code to revert the order if you wish.
